### PR TITLE
support merge_all_iters_to_one_epoch,  eval last 10 epochs after training

### DIFF
--- a/pcdet/datasets/dataset.py
+++ b/pcdet/datasets/dataset.py
@@ -34,6 +34,8 @@ class DatasetTemplate(torch_data.Dataset):
 
         self.grid_size = self.data_processor.grid_size
         self.voxel_size = self.data_processor.voxel_size
+        self.total_epochs = 0
+        self._merge_all_iters_to_one_epoch = False
 
     @property
     def mode(self):
@@ -64,6 +66,13 @@ class DatasetTemplate(torch_data.Dataset):
         Returns:
 
         """
+
+    def merge_all_iters_to_one_epoch(self, merge=True, epochs=None):
+        if merge:
+            self._merge_all_iters_to_one_epoch = True
+            self.total_epochs = epochs
+        else:
+            self._merge_all_iters_to_one_epoch = False
 
     def __len__(self):
         raise NotImplementedError

--- a/pcdet/datasets/kitti/kitti_dataset.py
+++ b/pcdet/datasets/kitti/kitti_dataset.py
@@ -330,10 +330,16 @@ class KittiDataset(DatasetTemplate):
         return ap_result_str, ap_dict
 
     def __len__(self):
+        if self._merge_all_iters_to_one_epoch:
+            return len(self.kitti_infos) * self.total_epochs
+
         return len(self.kitti_infos)
 
     def __getitem__(self, index):
         # index = 4
+        if self._merge_all_iters_to_one_epoch:
+            index = index % len(self.kitti_infos)
+
         info = copy.deepcopy(self.kitti_infos[index])
 
         sample_idx = info['point_cloud']['lidar_idx']

--- a/tools/test.py
+++ b/tools/test.py
@@ -96,8 +96,9 @@ def repeat_eval_ckpt(model, test_loader, args, eval_output_dir, logger, ckpt_dir
         cur_epoch_id, cur_ckpt = get_no_evaluated_ckpt(ckpt_dir, ckpt_record_file, args)
         if cur_epoch_id == -1 or int(float(cur_epoch_id)) < args.start_epoch:
             wait_second = 30
-            print('Wait %s seconds for next check (progress: %.1f / %d minutes): %s \r'
-                  % (wait_second, total_time * 1.0 / 60, args.max_waiting_mins, ckpt_dir), end='', flush=True)
+            if cfg.LOCAL_RANK == 0:
+                print('Wait %s seconds for next check (progress: %.1f / %d minutes): %s \r'
+                      % (wait_second, total_time * 1.0 / 60, args.max_waiting_mins, ckpt_dir), end='', flush=True)
             time.sleep(wait_second)
             total_time += 30
             if total_time > args.max_waiting_mins * 60 and (first_eval is False):


### PR DESCRIPTION
support merge_all_iters_to_one_epoch to avoid deadlock when switching epochs, eval last 10 epochs after training