### PR TITLE
Add support for SpConv 1.1

### DIFF
--- a/pcdet/datasets/processor/data_processor.py
+++ b/pcdet/datasets/processor/data_processor.py
@@ -65,9 +65,9 @@ class DataProcessor(object):
             return partial(self.transform_points_to_voxels, voxel_generator=voxel_generator)
 
         points = data_dict['points']
-        if voxel_generator.__name__ == 'VoxelGenerator':
+        if voxel_generator.__class__.__name__ == 'VoxelGenerator':
             voxels, coordinates, num_points = voxel_generator.generate(points)
-        elif voxel_generator.__name__ == 'VoxelGeneratorV2':
+        elif voxel_generator.__class__.__name__ == 'VoxelGeneratorV2':
             res = voxel_generator.generate(points)
             voxels, coordinates, num_points = res["voxels"], res["coordinates"], res["num_points_per_voxel"]
         else:


### PR DESCRIPTION
As SpConv 1.1 is compatible to newer Pytorch versions and able to compile on CUDA-Toolkit 10.2, a support for SpConv 1.1 is much desirable. 

This pull request contains a workaround for the `VoxelGenerator`  class. If available `VoxelGeneratorV2` (SpConv 1.1) will be used, otherwise `VoxelGenerator` (SpConv 1.0) is used.

Let me know what you think.