### PR TITLE
Fix NMS setting of kitti_models/second_multihead for evaluation / postprocessing

### DIFF
--- a/tools/cfgs/kitti_models/second_multihead.yaml
+++ b/tools/cfgs/kitti_models/second_multihead.yaml
@@ -101,14 +101,14 @@ MODEL:
 
     POST_PROCESSING:
         RECALL_THRESH_LIST: [0.3, 0.5, 0.7]
-        MULTI_CLASSES_NMS: False
+        MULTI_CLASSES_NMS: True
         SCORE_THRESH: 0.1
         OUTPUT_RAW_SCORE: False
 
         EVAL_METRIC: kitti
 
         NMS_CONFIG:
-            MULTI_CLASSES_NMS: False
+            MULTI_CLASSES_NMS: True
             NMS_TYPE: nms_gpu
             NMS_THRESH: 0.1
             NMS_PRE_MAXSIZE: 4096


### PR DESCRIPTION
If `MULTI_CLASSES_NMS` is set to `False`, the evaluation of the model based on the config 
`tools/cfgs/kitti_models/second_multihead.yaml` will crash with the output below.

If `MULTI_CLASSES_NMS` is set to `True`, the evaluation runs as expected. 

```bash
2020-09-02 12:54:51,403   INFO  *************** EPOCH 1 EVALUATION *****************

eval:   0%|          | 0/943 [00:00<?, ?it/s]Traceback (most recent call last):
  File "train.py", line 217, in <module>
    main()
  File "train.py", line 211, in main
    dist_test=dist_train
  File "/scratch_net/hox/mhahner/repositories/OpenPCDet/tools/test.py", line 121, in repeat_eval_ckpt
    result_dir=cur_result_dir, save_to_file=args.save_to_file
  File "/scratch_net/hox/mhahner/repositories/OpenPCDet/tools/eval_utils/eval_utils.py", line 56, in eval_one_epoch
    pred_dicts, ret_dict = model(batch_dict)
  File "/home/mhahner/scratch/apps/anaconda3/envs/PCDet/lib/python3.6/site-packages/torch/nn/modules/module.py", line 493, in __call__
    result = self.forward(*input, **kwargs)
  File "/home/mhahner/scratch/apps/anaconda3/envs/PCDet/lib/python3.6/site-packages/torch/nn/parallel/distributed.py", line 376, in forward
    output = self.module(*inputs[0], **kwargs[0])
  File "/home/mhahner/scratch/apps/anaconda3/envs/PCDet/lib/python3.6/site-packages/torch/nn/modules/module.py", line 493, in __call__
    result = self.forward(*input, **kwargs)
  File "/scratch_net/hox/mhahner/repositories/OpenPCDet/pcdet/models/detectors/second_net.py", line 21, in forward
    pred_dicts, recall_dicts = self.post_processing(batch_dict)
  File "/scratch_net/hox/mhahner/repositories/OpenPCDet/pcdet/models/detectors/detector3d_template.py", line 241, in post_processing
    cls_preds, label_preds = torch.max(cls_preds, dim=-1)
TypeError: max() received an invalid combination of arguments - got (list, dim=int), but expected one of:
 * (Tensor input)
 * (Tensor input, Tensor other, Tensor out)
 * (Tensor input, int dim, bool keepdim, tuple of Tensors out)
```