### PR TITLE
Removed trailing spaces that broke commands in GETTING_STARTED.md

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -52,7 +52,7 @@ pip install nuscenes-devkit==1.0.5
 
 * Generate the data infos by running the following command (it may take several hours): 
 ```python 
-python -m pcdet.datasets.nuscenes.nuscenes_dataset --func create_nuscenes_infos \ 
+python -m pcdet.datasets.nuscenes.nuscenes_dataset --func create_nuscenes_infos \
     --cfg_file tools/cfgs/dataset_configs/nuscenes_dataset.yaml \
     --version v1.0-trainval
 ```
@@ -115,7 +115,7 @@ sh scripts/dist_test.sh ${NUM_GPUS} \
 
 # or
 
-sh scripts/slurm_test_mgpu.sh ${PARTITION} ${NUM_GPUS} \ 
+sh scripts/slurm_test_mgpu.sh ${PARTITION} ${NUM_GPUS} \
     --cfg_file ${CONFIG_FILE} --batch_size ${BATCH_SIZE}
 ```
 


### PR DESCRIPTION
Tiny change: Removes trailing spaces from commands in GETTING_STARTED.md

The backslash `\` is meant to escape the newline when writing multi-line commands. But because there was a space character after the backslash, the backslash escaped the *space* and not the newline, and the command would not work properly.

Example:

```
python -m pcdet.datasets.nuscenes.nuscenes_dataset --func create_nuscenes_infos \ 
    --cfg_file tools/cfgs/dataset_configs/nuscenes_dataset.yaml \
    --version v1.0-trainval
```