### PR TITLE
fix: AssertionError features.is_contiguous() in pointnet2_utils.py

### DIFF
--- a/pcdet/models/backbones_3d/pointnet2_backbone.py
+++ b/pcdet/models/backbones_3d/pointnet2_backbone.py
@@ -75,7 +75,7 @@ class PointNet2MSG(nn.Module):
 
         assert xyz_batch_cnt.min() == xyz_batch_cnt.max()
         xyz = xyz.view(batch_size, -1, 3)
-        features = features.view(batch_size, -1, features.shape[-1]).permute(0, 2, 1) if features is not None else None
+        features = features.view(batch_size, -1, features.shape[-1]).permute(0, 2, 1).contiguous() if features is not None else None
 
         l_xyz, l_features = [xyz], [features]
         for i in range(len(self.SA_modules)):


### PR DESCRIPTION
An AssertionError is raised in pointnet2_utils.py.  
![微信截图_20210120053713](https://user-images.githubusercontent.com/46821571/105096152-a65a2880-5ae1-11eb-8031-6520544f3e5a.png)
This error may be caused by `features` in pointnet2_backbone.py:78, which is possible to be a non-contiguous tensor, being directly passed into SA_modules without calling .contiguous().  
So my fix is calling features.contiguous() to make sure it is contiguous before passed into SA_modules.  
Thank you!  
