### PR TITLE
fix: error of sample_points when num_point < far_idx_choice

### DIFF
--- a/pcdet/datasets/processor/data_processor.py
+++ b/pcdet/datasets/processor/data_processor.py
@@ -88,7 +88,6 @@ class DataProcessor(object):
             pts_near_flag = pts_depth < 40.0
             far_idxs_choice = np.where(pts_near_flag == 0)[0]
             near_idxs = np.where(pts_near_flag == 1)[0]
-            near_idxs_choice = np.random.choice(near_idxs, num_points - len(far_idxs_choice), replace=False)
             choice = []
             if num_points > len(far_idxs_choice):
                 near_idxs_choice = np.random.choice(near_idxs, num_points - len(far_idxs_choice), replace=False)


### PR DESCRIPTION
In data_processor.py sample_points, when num_points < far_idx_choice, a negative value is passed into np.random.choice, which cause a ValueError.
![微信截图_20210120054334](https://user-images.githubusercontent.com/46821571/105097057-f2f23380-5ae2-11eb-8833-35b10672e9e5.png)
![微信截图_20210120054406](https://user-images.githubusercontent.com/46821571/105097062-f5ed2400-5ae2-11eb-8867-17d5ad7cc906.png)

In fact the variable `near_idxs_choice` returned by the deleted line is never used. The following lines check whether num_points > far_idx_choice (then randomly choose from near_idx), or when num_points <= far_idx_choice (just randomly choose from all points), so there may be no use to call np.random.choice at the deleted line.  
btw, this error occurs when I try to train a PointRCNN with NuScenes dataset, which (perhaps) has relatively more points than that in Kitti?  
Thank you!