### PR TITLE
Fix issue if there are less than half of NUM_KEYPOINTS

### DIFF
--- a/pcdet/models/backbones_3d/pfe/voxel_set_abstraction.py
+++ b/pcdet/models/backbones_3d/pfe/voxel_set_abstraction.py
@@ -141,8 +141,9 @@ class VoxelSetAbstraction(nn.Module):
                 ).long()
 
                 if sampled_points.shape[1] < self.model_cfg.NUM_KEYPOINTS:
-                    empty_num = self.model_cfg.NUM_KEYPOINTS - sampled_points.shape[1]
-                    cur_pt_idxs[0, -empty_num:] = cur_pt_idxs[0, :empty_num]
+                    times = int(self.model_cfg.NUM_KEYPOINTS / sampled_points.shape[1]) + 1
+                    non_empty = cur_pt_idxs[0, :sampled_points.shape[1]]
+                    cur_pt_idxs[0] = non_empty.repeat(times)[:self.model_cfg.NUM_KEYPOINTS]
 
                 keypoints = sampled_points[0][cur_pt_idxs[0]].unsqueeze(dim=0)
 


### PR DESCRIPTION
If there are less than half of model_cfg.NUM_KEYPOINTS it will lead to 
RuntimeError: unsupported operation: some elements of the input tensor and the written-to tensor refer to a single memory location. 
Please clone() the tensor before performing the operation.