### PR TITLE
fix import order between mayavi and torch

### DIFF
--- a/tools/demo.py
+++ b/tools/demo.py
@@ -2,9 +2,9 @@ import argparse
 import glob
 from pathlib import Path
 
-import mayavi.mlab as mlab
 import numpy as np
 import torch
+import mayavi.mlab as mlab
 
 from pcdet.config import cfg, cfg_from_yaml_file
 from pcdet.datasets import DatasetTemplate


### PR DESCRIPTION
If we import the packages as the following orders, we get the error as shown in the figure.

```
import mayavi.mlab as mlab
import numpy as np
import torch
```

![order-error](https://user-images.githubusercontent.com/36033208/137090370-729c430b-f99b-464b-ab6e-1838c335515e.png)

After i updated the import orders in the following orders, the bug disappeared.

```
import numpy as np
import torch
import mayavi.mlab as mlab
```

***

We verify the orders in a simple way.

- case 1

  ```
   >>> import mayavi.mlab as mlab
   >>> import torch
   >>> a = torch.rand(5, 3)
   >>> b = a.cuda()
  Traceback (most recent call last):
    File "<stdin>", line 1, in <module>
  RuntimeError: CUDA error: invalid argument
   >>> exit()
  ```
- case 2

  ```
  >>> import torch
  >>> import mayavi.mlab as mlab
  >>> a = torch.rand(5, 3)
  >>> b = a.cuda()
  >>> exit()
  ```
- case 3

  ```
  >>> import mayavi
  >>> import torch
  >>> a = torch.rand(5, 3)
  >>> b = a.cuda()
  >>> exit()
  ```
- case 4

  ```
  >>> import torch
  >>> import mayavi
  >>> a = torch.rand(5, 3)
  >>> b = a.cuda()
  >>> exit()
  ```

So, if we should `import  mayavi.mlab` after `import torch`. However, the orders are not important if we just ` import mayavi`. 


