### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ numba
 torch>=1.1
 tensorboardX
 easydict
-pyyaml
+pyyaml<5.4
 scikit-image
 tqdm
 torchvision


### PR DESCRIPTION
As #662 and [PyYAML yaml.load(input) Deprecation](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation), the load() function requires parameter loader=Loader in new version of pyyaml and it will cause an error.
