### PR TITLE
Use yaml.safe_load instead of yaml.load

### DIFF
--- a/pcdet/config.py
+++ b/pcdet/config.py
@@ -52,9 +52,9 @@ def merge_new_config(config, new_config):
     if '_BASE_CONFIG_' in new_config:
         with open(new_config['_BASE_CONFIG_'], 'r') as f:
             try:
-                yaml_config = yaml.load(f, Loader=yaml.FullLoader)
+                yaml_config = yaml.safe_load(f, Loader=yaml.FullLoader)
             except:
-                yaml_config = yaml.load(f)
+                yaml_config = yaml.safe_load(f)
         config.update(EasyDict(yaml_config))
 
     for key, val in new_config.items():
@@ -71,9 +71,9 @@ def merge_new_config(config, new_config):
 def cfg_from_yaml_file(cfg_file, config):
     with open(cfg_file, 'r') as f:
         try:
-            new_config = yaml.load(f, Loader=yaml.FullLoader)
+            new_config = yaml.safe_load(f, Loader=yaml.FullLoader)
         except:
-            new_config = yaml.load(f)
+            new_config = yaml.safe_load(f)
 
         merge_new_config(config=config, new_config=new_config)
 

--- a/pcdet/datasets/kitti/kitti_dataset.py
+++ b/pcdet/datasets/kitti/kitti_dataset.py
@@ -473,7 +473,7 @@ if __name__ == '__main__':
         import yaml
         from pathlib import Path
         from easydict import EasyDict
-        dataset_cfg = EasyDict(yaml.load(open(sys.argv[2])))
+        dataset_cfg = EasyDict(yaml.safe_load(open(sys.argv[2])))
         ROOT_DIR = (Path(__file__).resolve().parent / '../../../').resolve()
         create_kitti_infos(
             dataset_cfg=dataset_cfg,

--- a/pcdet/datasets/nuscenes/nuscenes_dataset.py
+++ b/pcdet/datasets/nuscenes/nuscenes_dataset.py
@@ -356,7 +356,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     if args.func == 'create_nuscenes_infos':
-        dataset_cfg = EasyDict(yaml.load(open(args.cfg_file)))
+        dataset_cfg = EasyDict(yaml.safe_load(open(args.cfg_file)))
         ROOT_DIR = (Path(__file__).resolve().parent / '../../../').resolve()
         dataset_cfg.VERSION = args.version
         create_nuscenes_info(

--- a/pcdet/datasets/waymo/waymo_dataset.py
+++ b/pcdet/datasets/waymo/waymo_dataset.py
@@ -458,9 +458,9 @@ if __name__ == '__main__':
         import yaml
         from easydict import EasyDict
         try:
-            yaml_config = yaml.load(open(args.cfg_file), Loader=yaml.FullLoader)
+            yaml_config = yaml.safe_load(open(args.cfg_file), Loader=yaml.FullLoader)
         except:
-            yaml_config = yaml.load(open(args.cfg_file))
+            yaml_config = yaml.safe_load(open(args.cfg_file))
         dataset_cfg = EasyDict(yaml_config)
         ROOT_DIR = (Path(__file__).resolve().parent / '../../../').resolve()
         dataset_cfg.PROCESSED_DATA_TAG = args.processed_data_tag


### PR DESCRIPTION
As #662 and [PyYAML yaml.load(input) Deprecation](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation), the load() function requires parameter `loader=Loader` in new version of pyyaml and it will cause an error.
This PR using `yaml.safe_load` instead of `yaml.load` to adapt with all the yaml version