### PR TITLE
fixed a training bug (NameError: name 'copy' is not defined)

### DIFF
--- a/pcdet/datasets/augmentor/augmentor_utils.py
+++ b/pcdet/datasets/augmentor/augmentor_utils.py
@@ -1,6 +1,6 @@
 import numpy as np
 import math
-
+import copy
 from ...utils import common_utils
 
 


### PR DESCRIPTION
fixed a training bug.

When I run:  ` bash scripts/dist_train.sh 4 --cfg_file cfgs/kitti_models/CaDDN.yaml `
It shows the following bug:

`
NameError: Caught NameError in DataLoader worker process 0.
Original Traceback (most recent call last):
  File "/home/dkliang/miniconda3/envs/openpcdet/lib/python3.6/site-packages/torch/utils/data/_utils/worker.py", line 185, in _worker_loop
    data = fetcher.fetch(index)
  File "/home/dkliang/miniconda3/envs/openpcdet/lib/python3.6/site-packages/torch/utils/data/_utils/fetch.py", line 44, in fetch
    data = [self.dataset[idx] for idx in possibly_batched_index]
  File "/home/dkliang/miniconda3/envs/openpcdet/lib/python3.6/site-packages/torch/utils/data/_utils/fetch.py", line 44, in <listcomp>
    data = [self.dataset[idx] for idx in possibly_batched_index]
  File "../pcdet/datasets/kitti/kitti_dataset.py", line 424, in __getitem__
    data_dict = self.prepare_data(data_dict=input_dict)
  File "../pcdet/datasets/dataset.py", line 130, in prepare_data
    'gt_boxes_mask': gt_boxes_mask
  File "../pcdet/datasets/augmentor/data_augmentor.py", line 218, in forward
    data_dict = cur_augmentor(data_dict=data_dict)
  File "../pcdet/datasets/augmentor/data_augmentor.py", line 93, in random_image_flip
    images, depth_maps, gt_boxes, calib,
  File "../pcdet/datasets/augmentor/augmentor_utils.py", line 101, in random_image_flip_horizontal
    aug_gt_boxes = copy.copy(gt_boxes)
NameError: name 'copy' is not defined
`

The main reason is that the latest version does not import the copy package.