### PR TITLE
Gt sampler sweeps

### DIFF
--- a/pcdet/datasets/dataset.py
+++ b/pcdet/datasets/dataset.py
@@ -141,23 +141,6 @@ class DatasetTemplate(torch_data.Dataset):
 
             if data_dict.get('gt_boxes2d', None) is not None:
                 data_dict['gt_boxes2d'] = data_dict['gt_boxes2d'][selected]
-             
-        if 'timestamp' in self.dataset_cfg.POINT_FEATURE_ENCODING.get('src_feature_list'):
-            if data_dict.get('points', None) is not None:
-                max_sweeps = self.dataset_cfg.get('MAX_SWEEPS', 1)
-                idx = self.dataset_cfg.POINT_FEATURE_ENCODING.get('src_feature_list').index('timestamp')
-                dt = np.round(data_dict['points'][:, idx], 2)
-                max_dt = sorted(np.unique(dt))[min(len(np.unique(dt))-1, max_sweeps-1)]
-                data_dict['points'] = data_dict['points'][dt <= max_dt]
-
-        if 'timestamp' in self.dataset_cfg.POINT_FEATURE_ENCODING.get('src_feature_list'):
-            if data_dict.get('points', None) is not None:
-                max_sweeps = self.dataset_cfg.get('MAX_SWEEPS', 1)
-                idx = self.dataset_cfg.POINT_FEATURE_ENCODING.get('src_feature_list').index('timestamp')
-                dt = np.round(data_dict['points'][:, idx], 2)
-                if np.unique(dt).shape[0] == max_sweeps:
-                    max_dt = sorted(np.unique(dt))[max_sweeps-1]
-                    data_dict['points'] = data_dict['points'][dt <= max_dt]
 
         if data_dict.get('points', None) is not None:
             data_dict = self.point_feature_encoder.forward(data_dict)

--- a/pcdet/datasets/processor/point_feature_encoder.py
+++ b/pcdet/datasets/processor/point_feature_encoder.py
@@ -30,6 +30,14 @@ class PointFeatureEncoder(object):
             data_dict['points']
         )
         data_dict['use_lead_xyz'] = use_lead_xyz
+        
+        if self.point_encoding_config.get('FILTER_SWEEPS', False) and 'timestamp' in self.src_feature_list:
+            max_sweeps = self.point_encoding_config.MAX_SWEEPS
+            idx = self.src_feature_list.index('timestamp')
+            dt = np.round(data_dict['points'][:, idx], 2)
+            max_dt = sorted(np.unique(dt))[min(len(np.unique(dt))-1, max_sweeps-1)]
+            data_dict['points'] = data_dict['points'][dt <= max_dt]
+        
         return data_dict
 
     def absolute_coordinates_encoding(self, points=None):
@@ -44,4 +52,5 @@ class PointFeatureEncoder(object):
             idx = self.src_feature_list.index(x)
             point_feature_list.append(points[:, idx:idx+1])
         point_features = np.concatenate(point_feature_list, axis=1)
+        
         return point_features, True

--- a/pcdet/datasets/processor/point_feature_encoder.py
+++ b/pcdet/datasets/processor/point_feature_encoder.py
@@ -31,8 +31,8 @@ class PointFeatureEncoder(object):
         )
         data_dict['use_lead_xyz'] = use_lead_xyz
         
-        if self.point_encoding_config.get('FILTER_SWEEPS', False) and 'timestamp' in self.src_feature_list:
-            max_sweeps = self.point_encoding_config.MAX_SWEEPS
+        if self.point_encoding_config.get('filter_sweeps', False) and 'timestamp' in self.src_feature_list:
+            max_sweeps = self.point_encoding_config.max_sweeps
             idx = self.src_feature_list.index('timestamp')
             dt = np.round(data_dict['points'][:, idx], 2)
             max_dt = sorted(np.unique(dt))[min(len(np.unique(dt))-1, max_sweeps-1)]


### PR DESCRIPTION
Fixes index error while inference: Because there is no gt_sampling while inference, the point cloud (e.g. the first frame) may contain points of one timestep only. MAX_SWEEPS-1 could be greater than 0 which would cause an index error. 