### PR TITLE
Create close_stale_issues.yml

### DIFF
--- a/.github/workflows/close_stale_issues.yml
+++ b/.github/workflows/close_stale_issues.yml
@@ -1,0 +1,26 @@
+# https://github.com/actions/stale
+# https://github.com/marketplace/actions/close-stale-issues
+# https://docs.github.com/en/actions/managing-issues-and-pull-requests/closing-inactive-issues
+
+name: close stale issues
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v4.1.0
+        with:
+          days-before-issue-stale: 30
+          days-before-issue-close: 14
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 30 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This workflow will flag issues that are open for more than 30 days without activity as _stale_ and then close them two weeks later if there is no activity in the meantime.

It is an attempt to clean up many old / _stale_ issues in this repository.