### PR TITLE
fix: fix TypeError in ROI subsampling function

### DIFF
--- a/pcdet/models/roi_heads/target_assigner/proposal_target_layer.py
+++ b/pcdet/models/roi_heads/target_assigner/proposal_target_layer.py
@@ -145,7 +145,7 @@ class ProposalTargetLayer(nn.Module):
             rand_num = np.floor(np.random.rand(self.roi_sampler_cfg.ROI_PER_IMAGE) * fg_num_rois)
             rand_num = torch.from_numpy(rand_num).type_as(max_overlaps).long()
             fg_inds = fg_inds[rand_num]
-            bg_inds = fg_inds[fg_inds < 0]
+            bg_inds = fg_inds[fg_inds < 0] # yield empty tensor
 
         elif bg_num_rois > 0 and fg_num_rois == 0:
             # sampling bg

--- a/pcdet/models/roi_heads/target_assigner/proposal_target_layer.py
+++ b/pcdet/models/roi_heads/target_assigner/proposal_target_layer.py
@@ -145,7 +145,7 @@ class ProposalTargetLayer(nn.Module):
             rand_num = np.floor(np.random.rand(self.roi_sampler_cfg.ROI_PER_IMAGE) * fg_num_rois)
             rand_num = torch.from_numpy(rand_num).type_as(max_overlaps).long()
             fg_inds = fg_inds[rand_num]
-            bg_inds = []
+            bg_inds = fg_inds[fg_inds < 0]
 
         elif bg_num_rois > 0 and fg_num_rois == 0:
             # sampling bg


### PR DESCRIPTION
The `subsample_rois` function will raise a TypeError if `fg_num_rois > 0 and bg_num_rois == 0`.
This is because the `bg_inds=[]` line. Later on `fg_inds` and `bg_inds` are concatenated with
`sampled_inds = torch.cat((fg_inds, bg_inds), dim=0)`. This will yield TypeError

Steps to reproduce:
```
>>> import torch
>>> a = torch.tensor([1,2,3])
>>> b = []
>>> torch.cat([a,b], axis=0)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: expected Tensor as element 1 in argument 0, but got list
```

An easy fix is to let `bg_inds` be an empty tensor of same dtype and device as `fg_inds`