### PR TITLE
fix a small bug

### DIFF
--- a/pcdet/models/detectors/detector3d_template.py
+++ b/pcdet/models/detectors/detector3d_template.py
@@ -299,7 +299,7 @@ class Detector3DTemplate(nn.Module):
 
         cur_gt = gt_boxes
         k = cur_gt.__len__() - 1
-        while k > 0 and cur_gt[k].sum() == 0:
+        while k >= 0 and cur_gt[k].sum() == 0:
             k -= 1
         cur_gt = cur_gt[:k + 1]
 

--- a/pcdet/models/roi_heads/target_assigner/proposal_target_layer.py
+++ b/pcdet/models/roi_heads/target_assigner/proposal_target_layer.py
@@ -90,7 +90,7 @@ class ProposalTargetLayer(nn.Module):
             cur_roi, cur_gt, cur_roi_labels, cur_roi_scores = \
                 rois[index], gt_boxes[index], roi_labels[index], roi_scores[index]
             k = cur_gt.__len__() - 1
-            while k > 0 and cur_gt[k].sum() == 0:
+            while k >= 0 and cur_gt[k].sum() == 0:
                 k -= 1
             cur_gt = cur_gt[:k + 1]
             cur_gt = cur_gt.new_zeros((1, cur_gt.shape[1])) if len(cur_gt) == 0 else cur_gt


### PR DESCRIPTION
If k>0 is used as the condition, cur_gt.shape[0] will always be greater than 0. For some scenes without targets, cur_gt will be a zero tensor with shape (1, 8), which affects recall_dict['gt'],  As a result, it affects the calculation of recall. 