### PR TITLE
Reflect the changes of the default behavior of grid_sample and affine_grid

### DIFF
--- a/pcdet/models/backbones_3d/vfe/image_vfe_modules/f2v/sampler.py
+++ b/pcdet/models/backbones_3d/vfe/image_vfe_modules/f2v/sampler.py
@@ -1,3 +1,5 @@
+from functools import partial
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -16,6 +18,11 @@ class Sampler(nn.Module):
         self.mode = mode
         self.padding_mode = padding_mode
 
+        if torch.__version__ >= '1.3':
+            self.grid_sample = partial(F.grid_sample, align_corners=True)
+        else:
+            self.grid_sample = F.grid_sample
+
     def forward(self, input_features, grid):
         """
         Samples input using sampling grid
@@ -26,6 +33,5 @@ class Sampler(nn.Module):
             output_features: (B, C, X, Y, Z) Output voxel features
         """
         # Sample from grid
-        output = F.grid_sample(input=input_features, grid=grid, mode=self.mode, padding_mode=self.padding_mode,
-                               align_corners=True)
+        output = self.grid_sample(input=input_features, grid=grid, mode=self.mode, padding_mode=self.padding_mode)
         return output

--- a/pcdet/models/backbones_3d/vfe/image_vfe_modules/f2v/sampler.py
+++ b/pcdet/models/backbones_3d/vfe/image_vfe_modules/f2v/sampler.py
@@ -26,5 +26,6 @@ class Sampler(nn.Module):
             output_features: (B, C, X, Y, Z) Output voxel features
         """
         # Sample from grid
-        output = F.grid_sample(input=input_features, grid=grid, mode=self.mode, padding_mode=self.padding_mode)
+        output = F.grid_sample(input=input_features, grid=grid, mode=self.mode, padding_mode=self.padding_mode,
+                               align_corners=True)
         return output

--- a/pcdet/models/roi_heads/second_head.py
+++ b/pcdet/models/roi_heads/second_head.py
@@ -1,5 +1,8 @@
+from functools import partial
+
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 from .roi_head_template import RoIHeadTemplate
 from ...utils import common_utils, loss_utils
 
@@ -30,6 +33,13 @@ class SECONDHead(RoIHeadTemplate):
             input_channels=pre_channel, output_channels=1, fc_list=self.model_cfg.IOU_FC
         )
         self.init_weights(weight_init='xavier')
+
+        if torch.__version__ >= '1.3':
+            self.affine_grid = partial(F.affine_grid, align_corners=True)
+            self.grid_sample = partial(F.grid_sample, align_corners=True)
+        else:
+            self.affine_grid = F.affine_grid
+            self.grid_sample = F.grid_sample
 
     def init_weights(self, weight_init='xavier'):
         if weight_init == 'kaiming':
@@ -92,16 +102,14 @@ class SECONDHead(RoIHeadTemplate):
             ), dim=1).view(-1, 2, 3).float()
 
             grid_size = self.model_cfg.ROI_GRID_POOL.GRID_SIZE
-            grid = nn.functional.affine_grid(
+            grid = self.affine_grid(
                 theta,
-                torch.Size((rois.size(1), spatial_features_2d.size(1), grid_size, grid_size)),
-                align_corners=True
+                torch.Size((rois.size(1), spatial_features_2d.size(1), grid_size, grid_size))
             )
 
-            pooled_features = nn.functional.grid_sample(
+            pooled_features = self.grid_sample(
                 spatial_features_2d[b_id].unsqueeze(0).expand(rois.size(1), spatial_features_2d.size(1), height, width),
-                grid,
-                align_corners=True
+                grid
             )
 
             pooled_features_list.append(pooled_features)

--- a/pcdet/models/roi_heads/second_head.py
+++ b/pcdet/models/roi_heads/second_head.py
@@ -94,12 +94,14 @@ class SECONDHead(RoIHeadTemplate):
             grid_size = self.model_cfg.ROI_GRID_POOL.GRID_SIZE
             grid = nn.functional.affine_grid(
                 theta,
-                torch.Size((rois.size(1), spatial_features_2d.size(1), grid_size, grid_size))
+                torch.Size((rois.size(1), spatial_features_2d.size(1), grid_size, grid_size)),
+                align_corners=True
             )
 
             pooled_features = nn.functional.grid_sample(
                 spatial_features_2d[b_id].unsqueeze(0).expand(rois.size(1), spatial_features_2d.size(1), height, width),
-                grid
+                grid,
+                align_corners=True
             )
 
             pooled_features_list.append(pooled_features)


### PR DESCRIPTION
If PyTorch >= 1.3.0 `align_corners` will be set to `False` by default (but `True` is expected). This drastically reduces the SECONDIoU performance.

Evaluation of the KITTI model from the model zoo before changes:
```
Car AP@0.70, 0.70, 0.70:
bbox AP:89.7310, 88.8442, 88.5237
bev  AP:87.9080, 86.0925, 85.3315
3d   AP:84.9374, 76.3029, 75.9794
aos  AP:89.72, 88.73, 88.33
Car AP_R40@0.70, 0.70, 0.70:
bbox AP:94.6412, 93.1969, 91.1178
bev  AP:90.2307, 86.6130, 86.3666
3d   AP:86.7701, 79.2383, 77.1712
aos  AP:94.62, 93.06, 90.90
Car AP@0.70, 0.50, 0.50:
bbox AP:89.7310, 88.8442, 88.5237
bev  AP:89.8455, 92.4825, 88.7309
3d   AP:89.8455, 88.9443, 88.6950
aos  AP:89.72, 88.73, 88.33
Car AP_R40@0.70, 0.50, 0.50:
bbox AP:94.6412, 93.1969, 91.1178
bev  AP:94.7744, 94.6186, 93.4341
3d   AP:94.7605, 93.5132, 93.3093
aos  AP:94.62, 93.06, 90.90
Pedestrian AP@0.50, 0.50, 0.50:
bbox AP:52.6865, 50.1583, 48.8715
bev  AP:41.8535, 38.3748, 36.5096
3d   AP:37.2133, 34.9030, 32.1629
aos  AP:48.68, 46.20, 44.69
Pedestrian AP_R40@0.50, 0.50, 0.50:
bbox AP:51.2331, 48.3129, 46.9594
bev  AP:40.6510, 37.6296, 35.3592
3d   AP:36.4529, 33.5773, 31.1664
aos  AP:46.64, 43.80, 42.16
Pedestrian AP@0.50, 0.25, 0.25:
bbox AP:52.6865, 50.1583, 48.8715
bev  AP:55.4892, 54.5069, 53.4370
3d   AP:55.2917, 54.0297, 53.0834
aos  AP:48.68, 46.20, 44.69
Pedestrian AP_R40@0.50, 0.25, 0.25:
bbox AP:51.2331, 48.3129, 46.9594
bev  AP:54.4850, 53.4042, 51.6815
3d   AP:54.3276, 52.6706, 51.2269
aos  AP:46.64, 43.80, 42.16
Cyclist AP@0.50, 0.50, 0.50:
bbox AP:87.5908, 77.1372, 73.2886
bev  AP:84.6306, 66.8497, 63.4334
3d   AP:80.4156, 64.2871, 60.1949
aos  AP:87.18, 76.37, 72.42
Cyclist AP_R40@0.50, 0.50, 0.50:
bbox AP:89.8786, 77.8317, 74.4593
bev  AP:86.4507, 67.7289, 63.3873
3d   AP:83.1880, 63.7510, 60.2381
aos  AP:89.44, 77.03, 73.53
Cyclist AP@0.50, 0.25, 0.25:
bbox AP:87.5908, 77.1372, 73.2886
bev  AP:85.2689, 71.9390, 67.7767
3d   AP:85.2689, 71.9390, 67.7767
aos  AP:87.18, 76.37, 72.42
Cyclist AP_R40@0.50, 0.25, 0.25:
bbox AP:89.8786, 77.8317, 74.4593
bev  AP:87.2232, 72.4660, 68.5129
3d   AP:87.2232, 72.4660, 68.5129
aos  AP:89.44, 77.03, 73.53
```

and after changes:
```
Car AP@0.70, 0.70, 0.70:
bbox AP:90.8355, 89.8388, 89.2723
bev  AP:90.2623, 88.1195, 87.1185
3d   AP:89.2615, 79.0942, 78.1158
aos  AP:90.83, 89.77, 89.14
Car AP_R40@0.70, 0.70, 0.70:
bbox AP:95.8844, 94.2788, 92.0230
bev  AP:92.8479, 88.7489, 88.1442
3d   AP:91.5531, 82.3773, 79.6268
aos  AP:95.87, 94.19, 91.88
Car AP@0.70, 0.50, 0.50:
bbox AP:90.8355, 89.8388, 89.2723
bev  AP:90.8161, 93.6902, 89.4748
3d   AP:90.8161, 89.9144, 89.4485
aos  AP:90.83, 89.77, 89.14
Car AP_R40@0.70, 0.50, 0.50:
bbox AP:95.8844, 94.2788, 92.0230
bev  AP:95.8948, 95.8533, 94.3312
3d   AP:95.8869, 94.6650, 94.2326
aos  AP:95.87, 94.19, 91.88
Pedestrian AP@0.50, 0.50, 0.50:
bbox AP:71.1053, 66.2971, 63.3369
bev  AP:65.8997, 60.1765, 55.5646
3d   AP:61.3467, 55.7389, 51.2661
aos  AP:67.46, 62.55, 59.29
Pedestrian AP_R40@0.50, 0.50, 0.50:
bbox AP:71.7175, 66.8540, 63.0351
bev  AP:65.8063, 59.5335, 54.5955
3d   AP:61.1209, 54.5565, 49.4976
aos  AP:67.67, 62.70, 58.59
Pedestrian AP@0.50, 0.25, 0.25:
bbox AP:71.1053, 66.2971, 63.3369
bev  AP:76.8669, 73.8688, 69.7325
3d   AP:76.7553, 73.6554, 69.5219
aos  AP:67.46, 62.55, 59.29
Pedestrian AP_R40@0.50, 0.25, 0.25:
bbox AP:71.7175, 66.8540, 63.0351
bev  AP:78.2582, 74.9524, 70.8233
3d   AP:78.1487, 74.7087, 70.5867
aos  AP:67.67, 62.70, 58.59
Cyclist AP@0.50, 0.50, 0.50:
bbox AP:91.1650, 80.3305, 75.6053
bev  AP:90.7041, 73.7771, 68.5652
3d   AP:86.7106, 71.3100, 65.0472
aos  AP:90.99, 79.94, 75.16
Cyclist AP_R40@0.50, 0.50, 0.50:
bbox AP:94.9268, 81.9768, 77.7136
bev  AP:93.5079, 74.8429, 69.8322
3d   AP:90.6940, 71.2502, 66.2613
aos  AP:94.75, 81.54, 77.23
Cyclist AP@0.50, 0.25, 0.25:
bbox AP:91.1650, 80.3305, 75.6053
bev  AP:90.1900, 78.2873, 73.5401
3d   AP:90.1900, 78.2873, 73.5401
aos  AP:90.99, 79.94, 75.16
Cyclist AP_R40@0.50, 0.25, 0.25:
bbox AP:94.9268, 81.9768, 77.7136
bev  AP:93.7524, 78.8351, 75.0348
3d   AP:93.7524, 78.8351, 75.0348
aos  AP:94.75, 81.54, 77.23
```
