### PR TITLE
fix the bug about loading npy or bin

### DIFF
--- a/pcdet/datasets/custom/custom_dataset.py
+++ b/pcdet/datasets/custom/custom_dataset.py
@@ -65,7 +65,11 @@ class CustomDataset(DatasetTemplate):
     def get_lidar(self, idx):
         lidar_file = self.root_path / 'points' / ('%s.npy' % idx)
         assert lidar_file.exists()
-        point_features = np.load(lidar_file)
+        point_features = np.load(lidar_file).reshape(-1,4)
+        # just like kitti load
+        # lidar_file = self.root_path / 'points' / ('%s.bin' % idx)
+        # assert lidar_file.exists()
+        # point_features = np.fromfile(lidar_file,dtype=np.float32).reshape(-1,4)
         return point_features
 
     def set_split(self, split):


### PR DESCRIPTION
Thank you for your support of custom datasets.When i was making the dataset with
 "python -m pcdet.datasets.custom.custom_dataset create_custom_infos tools/cfgs/dataset_configs/custom_dataset.yaml"
it told me that:
torch.from_numpy(points[:, 0:3]), torch.from_numpy(gt_boxes)
IndexError: too many indices for array: array is 1-dimensional, but 2 were indexed
And i found the function "get_lidar()" in custom_dataset.py was different from kitti_dataset.py.
I think the data should be reshaped