### PR TITLE
fix pillarnet post_processing

### DIFF
--- a/pcdet/models/detectors/pillarnet.py
+++ b/pcdet/models/detectors/pillarnet.py
@@ -32,3 +32,19 @@ class PillarNet(Detector3DTemplate):
 
         loss = loss_rpn
         return loss, tb_dict, disp_dict
+
+    def post_processing(self, batch_dict):
+        post_process_cfg = self.model_cfg.POST_PROCESSING
+        batch_size = batch_dict['batch_size']
+        final_pred_dict = batch_dict['final_box_dicts']
+        recall_dict = {}
+        for index in range(batch_size):
+            pred_boxes = final_pred_dict[index]['pred_boxes']
+
+            recall_dict = self.generate_recall_record(
+                box_preds=pred_boxes,
+                recall_dict=recall_dict, batch_index=index, data_dict=batch_dict,
+                thresh_list=post_process_cfg.RECALL_THRESH_LIST
+            )
+
+        return final_pred_dict, recall_dict


### PR DESCRIPTION
Because pillarnet uses CenterHead as DENSE_HEAD, it need to make it's own simple POST_PROCESSING, following CenterPoint detector