### PR TITLE
Fix a bug when train with USE_MULTIHEAD and kitti dataset

### DIFF
--- a/pcdet/models/dense_heads/anchor_head_template.py
+++ b/pcdet/models/dense_heads/anchor_head_template.py
@@ -181,9 +181,7 @@ class AnchorHeadTemplate(nn.Module):
         else:
             anchors = self.anchors
         anchors = anchors.view(1, -1, anchors.shape[-1]).repeat(batch_size, 1, 1)
-        box_preds = box_preds.view(batch_size, -1,
-                                   box_preds.shape[-1] // self.num_anchors_per_location if not self.use_multihead else
-                                   box_preds.shape[-1])
+        box_preds = box_preds.view(batch_size, -1, box_preds.shape[-1] // self.num_anchors_per_location)
         # sin(a - b) = sinacosb-cosasinb
         box_preds_sin, reg_targets_sin = self.add_sin_difference(box_preds, box_reg_targets)
         loc_loss_src = self.reg_loss_func(box_preds_sin, reg_targets_sin, weights=reg_weights)  # [N, M]


### PR DESCRIPTION
When kitti dataset USING USE_MULTIHEAD: True tag, a error below will appear.
```
  File "/home/ssd1T0/daodao/OpenPCDet-hova88/pcdet/models/dense_heads/anchor_head_template.py", line 140, in add_sin_difference
    rad_pred_encoding = torch.sin(boxes1[..., dim:dim + 1]) * torch.cos(boxes2[..., dim:dim + 1])
RuntimeError: The size of tensor a (16384) must match the size of tensor b (98304) at non-singleton dimension 1
```
And this PR fix it.