### PR TITLE
fix: waymo eval class name typo

### DIFF
--- a/pcdet/datasets/waymo/waymo_eval.py
+++ b/pcdet/datasets/waymo/waymo_eval.py
@@ -21,7 +21,7 @@ def limit_period(val, offset=0.5, period=np.pi):
 
 
 class OpenPCDetWaymoDetectionMetricsEstimator(tf.test.TestCase):
-    WAYMO_CLASSES = ['unknown', 'Vehicle', 'Pedestrian', 'Truck', 'Cyclist']
+    WAYMO_CLASSES = ['unknown', 'Vehicle', 'Pedestrian', 'Sign', 'Cyclist']
 
     def generate_waymo_type_results(self, infos, class_names, is_gt=False, fake_gt_infos=True):
         def boxes3d_kitti_fakelidar_to_lidar(boxes3d_lidar):


### PR DESCRIPTION
This causes errors when evaluating 'Sign' classes on the waymo dataset.
There is no class named 'Truck' in Waymo 3DOD dataset.
WAYMO_CLASSES must be same as in waymo_utils.py
https://github.com/open-mmlab/OpenPCDet/blob/b345b08c5d3e49ff82a5374d033ddd2b5e66253e/pcdet/datasets/waymo/waymo_utils.py#L20