### PR TITLE
Correct DB_INFO_PATH (Once dataset config)

### DIFF
--- a/tools/cfgs/dataset_configs/once_dataset.yaml
+++ b/tools/cfgs/dataset_configs/once_dataset.yaml
@@ -21,7 +21,7 @@ DATA_AUGMENTOR:
         - NAME: gt_sampling
           USE_ROAD_PLANE: False
           DB_INFO_PATH:
-              - once_dbinfos_train.pkl
+              - once_infos_train.pkl
           PREPARE: {
              filter_by_min_points: ['Car:5', 'Bus:5', 'Truck:5', 'Pedestrian:5', 'Cyclist:5'],
           }


### PR DESCRIPTION
Correct DB_INFO_PATH 
once_dbinfos_train.pkl -> once_infos_train.pkl
(Error occurs because of diffrence between path names)