### PR TITLE
Use timm style to record log by logger

### DIFF
--- a/pcdet/config.py
+++ b/pcdet/config.py
@@ -7,7 +7,7 @@ from easydict import EasyDict
 def log_config_to_file(cfg, pre='cfg', logger=None):
     for key, val in cfg.items():
         if isinstance(cfg[key], EasyDict):
-            logger.info('\n%s.%s = edict()' % (pre, key))
+            logger.info('----------- %s -----------' % (key))
             log_config_to_file(cfg[key], pre=pre + '.' + key, logger=logger)
             continue
         logger.info('%s.%s: %s' % (pre, key, val))

--- a/tools/train_utils/train_utils.py
+++ b/tools/train_utils/train_utils.py
@@ -25,6 +25,7 @@ def train_one_epoch(model, optimizer, train_loader, model_func, lr_scheduler, ac
         data_time = common_utils.AverageMeter()
         batch_time = common_utils.AverageMeter()
         forward_time = common_utils.AverageMeter()
+        losses_m = common_utils.AverageMeter()
 
     end = time.time()
     for cur_it in range(start_it, total_it_each_epoch):
@@ -73,9 +74,12 @@ def train_one_epoch(model, optimizer, train_loader, model_func, lr_scheduler, ac
 
         # log to console and tensorboard
         if rank == 0:
+            batch_size = batch.get('batch_size', None)
+            
             data_time.update(avg_data_time)
             forward_time.update(avg_forward_time)
             batch_time.update(avg_batch_time)
+            losses_m.update(loss.item() , batch_size)
             
             disp_dict.update({
                 'loss': loss.item(), 'lr': cur_lr, 'd_time': f'{data_time.val:.2f}({data_time.avg:.2f})',
@@ -90,14 +94,28 @@ def train_one_epoch(model, optimizer, train_loader, model_func, lr_scheduler, ac
                     trained_time_each_epoch = pbar.format_dict['elapsed']
                     remaining_second_each_epoch = second_each_iter * (total_it_each_epoch - cur_it)
                     remaining_second_all = second_each_iter * ((total_epochs - cur_epoch) * total_it_each_epoch - cur_it)
-
-                    disp_str = ', '.join([f'{key}={val}' for key, val in disp_dict.items() if key != 'lr'])
-                    disp_str += f', lr={disp_dict["lr"]}'
-                    batch_size = batch.get('batch_size', None)
-                    logger.info(f'epoch: {cur_epoch}/{total_epochs}, acc_iter={accumulated_iter}, cur_iter={cur_it}/{total_it_each_epoch}, batch_size={batch_size}, '
-                                f'time_cost(epoch): {tbar.format_interval(trained_time_each_epoch)}/{tbar.format_interval(remaining_second_each_epoch)}, '
-                                f'time_cost(all): {tbar.format_interval(trained_time_past_all)}/{tbar.format_interval(remaining_second_all)}, '
-                                f'{disp_str}')
+                    
+                    logger.info(
+                        'Train: {:>4d}/{} ({:>3.0f}%) [{:>4d}/{} ({:>3.0f}%)]  '
+                        'Loss: {loss.val:#.4g} ({loss.avg:#.3g})  '
+                        'LR: {lr:.3e}  '
+                        f'Time cost: {tbar.format_interval(trained_time_each_epoch)}/{tbar.format_interval(remaining_second_each_epoch)} ' 
+                        f'[{tbar.format_interval(trained_time_past_all)}/{tbar.format_interval(remaining_second_all)}]  '
+                        'Acc_iter{acc_iter:>10d}  '
+                        'Data time: {data_time.val:.2f}({data_time.avg:.2f})  '
+                        'Forward time: {forward_time.val:.2f}({forward_time.avg:.2f})  '
+                        'Batch time: {batch_time.val:.2f}({batch_time.avg:.2f})'.format(
+                            cur_epoch,total_epochs, 100. * cur_epoch / total_epochs,
+                            cur_it,total_it_each_epoch, 100. * cur_it / total_it_each_epoch,
+                            loss=losses_m,
+                            lr=cur_lr,
+                            acc_iter=accumulated_iter,
+                            data_time=data_time,
+                            forward_time=forward_time,
+                            batch_time=batch_time
+                            )
+                    )
+                    
                     if show_gpu_stat and accumulated_iter % (3 * logger_iter_interval) == 0:
                         # To show the GPU utilization, please install gpustat through "pip install gpustat"
                         gpu_info = os.popen('gpustat').read()

--- a/tools/train_utils/train_utils.py
+++ b/tools/train_utils/train_utils.py
@@ -101,11 +101,11 @@ def train_one_epoch(model, optimizer, train_loader, model_func, lr_scheduler, ac
                         'LR: {lr:.3e}  '
                         f'Time cost: {tbar.format_interval(trained_time_each_epoch)}/{tbar.format_interval(remaining_second_each_epoch)} ' 
                         f'[{tbar.format_interval(trained_time_past_all)}/{tbar.format_interval(remaining_second_all)}]  '
-                        'Acc_iter{acc_iter:>10d}  '
+                        'Acc_iter {acc_iter:<10d}  '
                         'Data time: {data_time.val:.2f}({data_time.avg:.2f})  '
                         'Forward time: {forward_time.val:.2f}({forward_time.avg:.2f})  '
                         'Batch time: {batch_time.val:.2f}({batch_time.avg:.2f})'.format(
-                            cur_epoch,total_epochs, 100. * cur_epoch / total_epochs,
+                            cur_epoch+1,total_epochs, 100. * (cur_epoch+1) / total_epochs,
                             cur_it,total_it_each_epoch, 100. * cur_it / total_it_each_epoch,
                             loss=losses_m,
                             lr=cur_lr,


### PR DESCRIPTION
1. Change `log_train_***.txt` to `train_***.log` so that this text can be highlighted in ide.
2. Record the log according to the style of [pytorch-image-models](https://github.com/rwightman/pytorch-image-models)
```log
2023-01-05 16:34:33,418   INFO  **********************Start training nuscenes_models/cbgs_voxel0075_res3d_centerpoint(timm_style)**********************
2023-01-05 16:34:37,748   INFO  Train:    1/3 ( 33%) [   0/323 (  0%)]  Loss: 516.7 (517.)  LR: 1.000e-04  Time cost: 00:04/21:46 [00:04/1:05:18]  Acc_iter 1           Data time: 0.87(0.87)  Forward time: 3.18(3.18)  Batch time: 4.04(4.04)
2023-01-05 16:34:49,377   INFO  Train:    1/3 ( 33%) [  49/323 ( 15%)]  Loss: 36.77 (81.7)  LR: 1.351e-04  Time cost: 00:15/01:25 [00:15/04:48]  Acc_iter 50          Data time: 0.00(0.02)  Forward time: 0.31(0.29)  Batch time: 0.31(0.31)
2023-01-05 16:35:00,786   INFO  Train:    1/3 ( 33%) [  99/323 ( 31%)]  Loss: 23.51 (54.8)  LR: 2.377e-04  Time cost: 00:27/01:00 [00:27/03:55]  Acc_iter 100         Data time: 0.00(0.01)  Forward time: 0.19(0.26)  Batch time: 0.20(0.27)
2023-01-05 16:35:11,175   INFO  Train:    1/3 ( 33%) [ 149/323 ( 46%)]  Loss: 28.79 (45.1)  LR: 3.910e-04  Time cost: 00:37/00:43 [00:37/03:24]  Acc_iter 150         Data time: 0.00(0.01)  Forward time: 0.14(0.24)  Batch time: 0.15(0.25)
2023-01-05 16:35:22,124   INFO  Train:    1/3 ( 33%) [ 199/323 ( 62%)]  Loss: 23.56 (39.8)  LR: 5.701e-04  Time cost: 00:48/00:30 [00:48/03:06]  Acc_iter 200         Data time: 0.00(0.01)  Forward time: 0.19(0.24)  Batch time: 0.20(0.24)
2023-01-05 16:35:32,667   INFO  Train:    1/3 ( 33%) [ 249/323 ( 77%)]  Loss: 19.39 (36.5)  LR: 7.460e-04  Time cost: 00:58/00:17 [00:59/02:49]  Acc_iter 250         Data time: 0.00(0.01)  Forward time: 0.28(0.23)  Batch time: 0.29(0.24)
2023-01-05 16:35:43,319   INFO  Train:    1/3 ( 33%) [ 299/323 ( 93%)]  Loss: 19.67 (34.2)  LR: 8.900e-04  Time cost: 01:09/00:05 [01:09/02:35]  Acc_iter 300         Data time: 0.00(0.01)  Forward time: 0.27(0.23)  Batch time: 0.27(0.23)
2023-01-05 16:35:47,906   INFO  Train:    1/3 ( 33%) [ 322/323 (100%)]  Loss: 23.89 (33.4)  LR: 9.388e-04  Time cost: 01:14/00:00 [01:14/02:28]  Acc_iter 323         Data time: 0.00(0.01)  Forward time: 0.14(0.22)  Batch time: 0.14(0.23)
2023-01-05 16:35:49,021   INFO  Train:    2/3 ( 67%) [   0/323 (  0%)]  Loss: 26.78 (26.8)  LR: 9.406e-04  Time cost: 00:00/04:46 [01:15/09:33]  Acc_iter 324         Data time: 0.49(0.49)  Forward time: 0.39(0.39)  Batch time: 0.89(0.89)
2023-01-05 16:35:54,039   INFO  Train:    2/3 ( 67%) [  26/323 (  8%)]  Loss: 25.13 (23.2)  LR: 9.788e-04  Time cost: 00:05/01:04 [01:20/02:15]  Acc_iter 350         Data time: 0.00(0.02)  Forward time: 0.21(0.20)  Batch time: 0.21(0.22)
2023-01-05 16:36:03,994   INFO  Train:    2/3 ( 67%) [  76/323 ( 24%)]  Loss: 24.75 (22.6)  LR: 9.990e-04  Time cost: 00:15/00:50 [01:30/01:57]  Acc_iter 400         Data time: 0.00(0.01)  Forward time: 0.19(0.20)  Batch time: 0.19(0.21)
2023-01-05 16:36:13,669   INFO  Train:    2/3 ( 67%) [ 126/323 ( 39%)]  Loss: 20.90 (22.2)  LR: 9.723e-04  Time cost: 00:25/00:39 [01:40/01:44]  Acc_iter 450         Data time: 0.00(0.01)  Forward time: 0.22(0.20)  Batch time: 0.22(0.20)
2023-01-05 16:36:23,137   INFO  Train:    2/3 ( 67%) [ 176/323 ( 54%)]  Loss: 23.41 (21.9)  LR: 9.114e-04  Time cost: 00:35/00:29 [01:49/01:32]  Acc_iter 500         Data time: 0.00(0.00)  Forward time: 0.14(0.19)  Batch time: 0.14(0.20)
2023-01-05 16:36:32,327   INFO  Train:    2/3 ( 67%) [ 226/323 ( 70%)]  Loss: 21.03 (21.6)  LR: 8.207e-04  Time cost: 00:44/00:18 [01:58/01:21]  Acc_iter 550         Data time: 0.00(0.00)  Forward time: 0.14(0.19)  Batch time: 0.14(0.19)
2023-01-05 16:36:41,883   INFO  Train:    2/3 ( 67%) [ 276/323 ( 85%)]  Loss: 19.83 (21.5)  LR: 7.068e-04  Time cost: 00:53/00:09 [02:08/01:11]  Acc_iter 600         Data time: 0.00(0.00)  Forward time: 0.19(0.19)  Batch time: 0.19(0.19)
2023-01-05 16:36:50,047   INFO  Train:    2/3 ( 67%) [ 322/323 (100%)]  Loss: 18.90 (21.2)  LR: 5.886e-04  Time cost: 01:01/00:00 [02:16/01:02]  Acc_iter 646         Data time: 0.00(0.00)  Forward time: 0.15(0.19)  Batch time: 0.15(0.19)
2023-01-05 16:36:51,106   INFO  Train:    3/3 (100%) [   0/323 (  0%)]  Loss: 21.00 (21.0)  LR: 5.859e-04  Time cost: 00:00/04:28 [02:17/04:28]  Acc_iter 647         Data time: 0.54(0.54)  Forward time: 0.29(0.29)  Batch time: 0.83(0.83)
2023-01-05 16:36:51,666   INFO  Train:    3/3 (100%) [   3/323 (  1%)]  Loss: 20.29 (20.3)  LR: 5.780e-04  Time cost: 00:01/01:51 [02:18/01:51]  Acc_iter 650         Data time: 0.00(0.14)  Forward time: 0.19(0.21)  Batch time: 0.20(0.35)
2023-01-05 16:37:01,307   INFO  Train:    3/3 (100%) [  53/323 ( 16%)]  Loss: 21.82 (20.0)  LR: 4.434e-04  Time cost: 00:11/00:55 [02:27/00:55]  Acc_iter 700         Data time: 0.00(0.01)  Forward time: 0.16(0.19)  Batch time: 0.16(0.20)
2023-01-05 16:37:10,328   INFO  Train:    3/3 (100%) [ 103/323 ( 32%)]  Loss: 23.87 (19.7)  LR: 3.130e-04  Time cost: 00:20/00:42 [02:36/00:42]  Acc_iter 750         Data time: 0.00(0.01)  Forward time: 0.15(0.19)  Batch time: 0.15(0.19)
2023-01-05 16:37:19,906   INFO  Train:    3/3 (100%) [ 153/323 ( 47%)]  Loss: 17.04 (19.6)  LR: 1.962e-04  Time cost: 00:29/00:32 [02:46/00:32]  Acc_iter 800         Data time: 0.00(0.01)  Forward time: 0.21(0.19)  Batch time: 0.21(0.19)
2023-01-05 16:37:29,243   INFO  Train:    3/3 (100%) [ 203/323 ( 63%)]  Loss: 18.42 (19.4)  LR: 1.013e-04  Time cost: 00:38/00:22 [02:55/00:22]  Acc_iter 850         Data time: 0.00(0.00)  Forward time: 0.17(0.19)  Batch time: 0.17(0.19)
2023-01-05 16:37:38,561   INFO  Train:    3/3 (100%) [ 253/323 ( 78%)]  Loss: 21.43 (19.3)  LR: 3.528e-05  Time cost: 00:48/00:13 [03:05/00:13]  Acc_iter 900         Data time: 0.00(0.00)  Forward time: 0.20(0.19)  Batch time: 0.20(0.19)
2023-01-05 16:37:48,159   INFO  Train:    3/3 (100%) [ 303/323 ( 94%)]  Loss: 16.19 (19.1)  LR: 2.921e-06  Time cost: 00:57/00:03 [03:14/00:03]  Acc_iter 950         Data time: 0.00(0.00)  Forward time: 0.23(0.19)  Batch time: 0.23(0.19)
2023-01-05 16:37:51,368   INFO  Train:    3/3 (100%) [ 322/323 (100%)]  Loss: 19.52 (19.0)  LR: 1.728e-08  Time cost: 01:01/00:00 [03:17/00:00]  Acc_iter 969         Data time: 0.00(0.00)  Forward time: 0.11(0.19)  Batch time: 0.11(0.19)
2023-01-05 16:37:51,550   INFO  **********************End training nuscenes_models/cbgs_voxel0075_res3d_centerpoint(timm_style)**********************
```
