### PR TITLE
fix import error, update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,4 @@ scikit-image
 tqdm
 torchvision
 SharedArray
-json
-cv2
+opencv-python


### PR DESCRIPTION
Thanks for the great project!
I am now trying to use this repository to do research on point cloud object detection.

- The `json` listed in `requirements.txt` is not necessary as it originally came as a standard library with the original. Rather, writing it caused an error.
- Also, we couldn't install `cv2` listed in `requirements.txt`, `opencv-python` is appropriate.

These problems have been fixed.

Thank you for your confirmation.