### PR TITLE
Fix AMP training error

### DIFF
--- a/pcdet/utils/loss_utils.py
+++ b/pcdet/utils/loss_utils.py
@@ -148,6 +148,7 @@ class WeightedL1Loss(nn.Module):
             self.code_weights = np.array(code_weights, dtype=np.float32)
             self.code_weights = torch.from_numpy(self.code_weights).cuda()
 
+    @torch.amp.cuda.custom_fwd(cast_inputs=torch.float16)
     def forward(self, input: torch.Tensor, target: torch.Tensor, weights: torch.Tensor = None):
         """
         Args:


### PR DESCRIPTION
Current AMP training does not convert `target` to float16, leading to a runtime error that can be reproduced simply by the following example command
```bash
bash scripts/dist_train.sh 8 --cfg_file cfgs/nuscenes_models/cbgs_pp_multihead.yaml
```
The aforementioned error can be fixed by this PR.