### PR TITLE
fix data_sampler bug

### DIFF
--- a/pcdet/datasets/augmentor/database_sampler.py
+++ b/pcdet/datasets/augmentor/database_sampler.py
@@ -498,5 +498,5 @@ class DataBaseSampler(object):
                 data_dict, sampled_gt_boxes, total_valid_sampled_dict, sampled_mv_height, sampled_gt_boxes2d
             )
 
-        data_dict.pop('gt_boxes_mask')
+            data_dict.pop('gt_boxes_mask')
         return data_dict


### PR DESCRIPTION
Fixed an issue where invalid gt_bboxes can not be removed when total_valid_sampled_dict.__len__() == 0