### PR TITLE
convert np.bool to np.bool_

### DIFF
--- a/pcdet/datasets/augmentor/augmentor_utils.py
+++ b/pcdet/datasets/augmentor/augmentor_utils.py
@@ -501,7 +501,7 @@ def one_hot(x, num_class=1):
 
 def points_in_pyramids_mask(points, pyramids):
     pyramids = pyramids.reshape(-1, 5, 3)
-    flags = np.zeros((points.shape[0], pyramids.shape[0]), dtype=np.bool)
+    flags = np.zeros((points.shape[0], pyramids.shape[0]), dtype=np.bool_)
     for i, pyramid in enumerate(pyramids):
         flags[:, i] = np.logical_or(flags[:, i], box_utils.in_hull(points[:, 0:3], pyramid))
     return flags

--- a/pcdet/datasets/kitti/kitti_object_eval_python/kitti_common.py
+++ b/pcdet/datasets/kitti/kitti_object_eval_python/kitti_common.py
@@ -262,9 +262,9 @@ def add_difficulty_to_annos(info):
     occlusion = annos['occluded']
     truncation = annos['truncated']
     diff = []
-    easy_mask = np.ones((len(dims), ), dtype=np.bool)
-    moderate_mask = np.ones((len(dims), ), dtype=np.bool)
-    hard_mask = np.ones((len(dims), ), dtype=np.bool)
+    easy_mask = np.ones((len(dims), ), dtype=np.bool_)
+    moderate_mask = np.ones((len(dims), ), dtype=np.bool_)
+    hard_mask = np.ones((len(dims), ), dtype=np.bool_)
     i = 0
     for h, o, t in zip(height, occlusion, truncation):
         if o > max_occlusion[0] or h <= min_height[0] or t > max_trunc[0]:

--- a/pcdet/utils/box_utils.py
+++ b/pcdet/utils/box_utils.py
@@ -20,7 +20,7 @@ def in_hull(p, hull):
         flag = hull.find_simplex(p) >= 0
     except scipy.spatial.qhull.QhullError:
         print('Warning: not a hull %s' % str(hull))
-        flag = np.zeros(p.shape[0], dtype=np.bool)
+        flag = np.zeros(p.shape[0], dtype=np.bool_)
 
     return flag
 


### PR DESCRIPTION
When I train pointpillar_pyramid_aug, the error occurs.
```python
AttributeError: module 'numpy' has no attribute 'bool'.
`np.bool` was a deprecated alias for the builtin `bool`. To avoid this error in existing code, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
```
Since np.bool is deprecated in numpy>=1.20, so I change the `np.bool` to `np.bool_` in files using `np.bool`.