### PR TITLE
changed to CUDA11.6.2 on ubuntu20.04, using openCV4.2.0 with GPU sup…

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,55 +1,83 @@
-FROM nvidia/cuda:10.2-cudnn7-devel-ubuntu18.04
+FROM nvidia/cuda:11.6.2-devel-ubuntu20.04
 
-RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+# Set environment variables
+ENV NVENCODE_CFLAGS "-I/usr/local/cuda/include"
+ENV CV_VERSION=4.2.0
+ENV DEBIAN_FRONTEND=noninteractive
 
-# Install basics
-RUN apt-get update -y \
-    && apt-get install build-essential \
-    && apt-get install -y apt-utils git curl ca-certificates bzip2 tree htop wget \
-    && apt-get install -y libglib2.0-0 libsm6 libxext6 libxrender-dev bmon iotop g++ python3.7 python3.7-dev python3.7-distutils
+# Get all dependencies
+RUN apt-get update && apt-get install -y \
+    git zip unzip libssl-dev libcairo2-dev lsb-release libgoogle-glog-dev libgflags-dev libatlas-base-dev libeigen3-dev software-properties-common \
+    build-essential cmake pkg-config libapr1-dev autoconf automake libtool curl libc6 libboost-all-dev debconf libomp5 libstdc++6 \
+    libqt5core5a libqt5xml5 libqt5gui5 libqt5widgets5 libqt5concurrent5 libqt5opengl5 libcap2 libusb-1.0-0 libatk-adaptor neovim \
+    python3-pip python3-tornado python3-dev python3-numpy python3-virtualenv libpcl-dev libgoogle-glog-dev libgflags-dev libatlas-base-dev \
+    libsuitesparse-dev python3-pcl pcl-tools libgtk2.0-dev libavcodec-dev libavformat-dev libswscale-dev libtbb2 libtbb-dev libjpeg-dev \
+    libpng-dev libtiff-dev libdc1394-22-dev xfce4-terminal &&\
+    rm -rf /var/lib/apt/lists/*
 
-# Install cmake v3.13.2
-RUN apt-get purge -y cmake && \
-    mkdir /root/temp && \
-    cd /root/temp && \
-    wget https://github.com/Kitware/CMake/releases/download/v3.13.2/cmake-3.13.2.tar.gz && \
-    tar -xzvf cmake-3.13.2.tar.gz && \
-    cd cmake-3.13.2 && \
-    bash ./bootstrap && \
-    make && \
-    make install && \
-    cmake --version && \
-    rm -rf /root/temp
+# OpenCV with CUDA support
+WORKDIR /opencv
+RUN git clone https://github.com/opencv/opencv.git -b $CV_VERSION &&\
+    git clone https://github.com/opencv/opencv_contrib.git -b $CV_VERSION
 
-# Install python
-RUN ln -sv /usr/bin/python3.7 /usr/bin/python
-RUN wget https://bootstrap.pypa.io/get-pip.py && \
-	python get-pip.py && \
-	rm get-pip.py
+# While using OpenCV 4.2.0 we have to apply some fixes to ensure that CUDA is fully supported, thanks @https://github.com/gismo07 for this fix
+RUN mkdir opencvfix && cd opencvfix &&\
+    git clone https://github.com/opencv/opencv.git -b 4.5.2 &&\
+    cd opencv/cmake &&\
+    cp -r FindCUDA /opencv/opencv/cmake/ &&\
+    cp FindCUDA.cmake /opencv/opencv/cmake/ &&\
+    cp FindCUDNN.cmake /opencv/opencv/cmake/ &&\
+    cp OpenCVDetectCUDA.cmake /opencv/opencv/cmake/
+ 
+WORKDIR /opencv/opencv/build
 
-# Install python packages
-RUN PIP_INSTALL="python -m pip --no-cache-dir install" && \
-    $PIP_INSTALL numpy==1.19.3 llvmlite numba 
+RUN cmake -D CMAKE_BUILD_TYPE=RELEASE \
+-D CMAKE_INSTALL_PREFIX=/usr/local \
+-D OPENCV_GENERATE_PKGCONFIG=ON \
+-D BUILD_EXAMPLES=OFF \
+-D INSTALL_PYTHON_EXAMPLES=OFF \
+-D INSTALL_C_EXAMPLES=OFF \
+-D PYTHON_EXECUTABLE=$(which python2) \
+-D PYTHON3_EXECUTABLE=$(which python3) \
+-D PYTHON3_INCLUDE_DIR=$(python3 -c "from distutils.sysconfig import get_python_inc; print(get_python_inc())") \
+-D PYTHON3_PACKAGES_PATH=$(python3 -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())") \
+-D BUILD_opencv_python2=ON \
+-D BUILD_opencv_python3=ON \
+-D OPENCV_EXTRA_MODULES_PATH=../../opencv_contrib/modules/ \
+-D WITH_GSTREAMER=ON \
+-D WITH_CUDA=ON \
+-D ENABLE_PRECOMPILED_HEADERS=OFF \
+.. &&\
+make -j$(nproc) &&\
+make install &&\
+ldconfig &&\
+rm -rf /opencv
 
-# Install torch and torchvision
-# See https://pytorch.org/ for other options if you use a different version of CUDA
-RUN pip install --user torch==1.6 torchvision==0.7.0 -f https://download.pytorch.org/whl/cu102/torch_stable.html
+WORKDIR /
+ENV OpenCV_DIR=/usr/share/OpenCV
 
-# Install python packages
-RUN PIP_INSTALL="python -m pip --no-cache-dir install" && \
-    $PIP_INSTALL tensorboardX easydict pyyaml scikit-image tqdm SharedArray six
 
-WORKDIR /root
+# PyTorch for CUDA 11.6
+RUN pip3 install torch==1.13.1+cu116 torchvision==0.14.1+cu116 torchaudio==0.13.1 --extra-index-url https://download.pytorch.org/whl/cu116
+ENV TORCH_CUDA_ARCH_LIST="3.5;5.0;6.0;6.1;7.0;7.5;8.0;8.6+PTX"
+    
+# OpenPCDet
+RUN pip3 install numpy==1.23.0 llvmlite numba tensorboardX easydict pyyaml scikit-image tqdm SharedArray open3d mayavi av2 kornia pyquaternion
+RUN pip3 install spconv-cu116
 
-# Install Boost geometry
-RUN wget https://jaist.dl.sourceforge.net/project/boost/boost/1.68.0/boost_1_68_0.tar.gz && \
-    tar xzvf boost_1_68_0.tar.gz && \
-    cp -r ./boost_1_68_0/boost /usr/include && \
-    rm -rf ./boost_1_68_0 && \
-    rm -rf ./boost_1_68_0.tar.gz 
+RUN git clone https://github.com/open-mmlab/OpenPCDet.git
 
-# A weired problem that hasn't been solved yet
-RUN pip uninstall -y SharedArray && \
-    pip install SharedArray
+WORKDIR OpenPCDet
 
-RUN pip install spconv-cu102
+RUN python3 setup.py develop
+    
+WORKDIR /
+
+ENV NVIDIA_VISIBLE_DEVICES="all" \
+    OpenCV_DIR=/usr/share/OpenCV \
+    NVIDIA_DRIVER_CAPABILITIES="video,compute,utility,graphics" \
+    LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/lib:/usr/lib:/usr/local/lib \
+    QT_GRAPHICSSYSTEM="native"
+
+# Build instructions: docker build -f minimal.Dockerfile -t openpcdet:cuda11 .
+# Start instructions: xhost local:root && docker run -it --rm -e SDL_VIDEODRIVER=x11 -e DISPLAY=$DISPLAY --env='DISPLAY' --gpus all --ipc host --privileged --network host -p 8080:8081 -v /tmp/.X11-unix:/tmp/.X11-unix:rw -v file_locations:/storage -v /weights:/weights openpcdet:cuda11 xfce4-terminal --title=openPCDet


### PR DESCRIPTION
While using newer GPUs, CUDA10 is not supported anymore. Thus, the updated Dockerfile uses CUDA11.6.2 on ubuntu 20.04. Additionally, openCV is build from source, supporting CUDA. 

To build the container: 
 `docker build -f minimal.Dockerfile -t openpcdet:cuda11 .`

Running the container with display-support: 
`xhost local:root && docker run -it --rm -e SDL_VIDEODRIVER=x11 -e DISPLAY=$DISPLAY --env='DISPLAY' --gpus all --ipc host --privileged --network host -p 8080:8081 -v /tmp/.X11-unix:/tmp/.X11-unix:rw -v file_locations:/storage -v /weights:/weights openpcdet:cuda11 xfce4-terminal --title=openPCDet`

